### PR TITLE
一覧と詳細画面にタグを表示

### DIFF
--- a/src/resources/views/articles/card.blade.php
+++ b/src/resources/views/articles/card.blade.php
@@ -69,4 +69,17 @@
       </article-like>
     </div>
   </div>
+  @foreach($article->tags as $tag)
+  @if($loop->first)
+  <div class="card-body pt-0 pb-4 pl-3">
+    <div class="card-text line-height">
+      @endif
+      <a href="" class="border p-1 mr-1 mt-1 text-muted">
+        {{ $tag->name }}
+      </a>
+      @if($loop->last)
+    </div>
+  </div>
+  @endif
+  @endforeach
 </div>


### PR DESCRIPTION
# 概要
・card.blade.phpに@foreachを使って記事に紐ずくタグの数だけ繰り返し処理を行いタグ名を表示