### PR TITLE
Vueコンポに記事のタグ情報を渡す

### DIFF
--- a/src/resources/views/articles/form.blade.php
+++ b/src/resources/views/articles/form.blade.php
@@ -4,7 +4,8 @@
   <input type="text" name="title" class="form-control" required value="{{ $article->title ?? old('title') }}">
 </div>
 <div class="form-group">
-  <article-tags-input>
+  <!-- 記事のタグ情報を渡す -->
+  <article-tags-input :initial-tags='@json($tagNames ?? [])'>
   </article-tags-input>
 </div>
 <div class="form-group">


### PR DESCRIPTION
# 概要
・form.blade.phpにArticleTagsInputに渡せるように定義