### PR TITLE
自動補完

### DIFF
--- a/src/resources/js/components/ArticleTagsInput.vue
+++ b/src/resources/js/components/ArticleTagsInput.vue
@@ -23,28 +23,15 @@ export default {
       type: Array,
       default: [],
     },
+    autocompleteltems: {
+      type: Array,
+      default: [],
+    },
   },
   data() {
     return {
       tag: "",
       tags: this.initialTags,
-      autocompleteItems: [
-        {
-          text: "Spain",
-        },
-        {
-          text: "France",
-        },
-        {
-          text: "USA",
-        },
-        {
-          text: "Germany",
-        },
-        {
-          text: "China",
-        },
-      ],
     };
   },
   computed: {


### PR DESCRIPTION
# 概要
・ArticleTagsInput.vueにautocompleteltemsで受け取り元々のVueコンポを削除